### PR TITLE
Fix wide equations overflowing on mobile

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -214,6 +214,13 @@
   .prose a {
     @apply break-words hover:!text-skin-accent;
   }
+  /* Let wide display equations scroll horizontally instead of stretching
+     the page (KaTeX uses white-space: nowrap, which broke mobile layout) */
+  .prose .katex-display {
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding-block: 0.5rem;
+  }
   /* Gentle backdrop for the transparent gradient-intuitions diagrams,
      so the dark line art stays legible on both light and dark themes */
   .prose img[src*="gradient-intuitions"] {


### PR DESCRIPTION
The long display equation in the gradient post stretched the page to 640px on a 390px screen (KaTeX renders display math with `white-space: nowrap`), so the whole post overflowed horizontally on mobile.

Fix: make `.prose .katex-display` a horizontal scroll container (`overflow-x: auto`). Wide equations now scroll within their own box instead of pushing the page wider. Equations that fit stay centered.

Verified with Playwright at 390px: page horizontal overflow went from 265px to 0.